### PR TITLE
Added value-chain support.

### DIFF
--- a/Promises/Promise.swift
+++ b/Promises/Promise.swift
@@ -167,6 +167,48 @@ public class Promise<V> {
         }
         return self
     }
+    
+
+    //  Values
+    //  ------
+    
+    var valueChain: Value?
+    
+    public func valueFor(key: UnsafePointer<Void>) -> Any? {
+        if let v = valueChain {
+            return v.valueFor(key)
+        } else {
+            return nil
+        }
+    }
+    
+    public func withValue(value: Any, forKey key: UnsafePointer<Void>) -> Self {
+        valueChain = Value(parent: valueChain, key: key, any: value)
+        return self
+    }
+}
+
+class Value {
+    let parent: Value?
+    let key: UnsafePointer<Void>
+    let any: Any
+    
+    init(parent: Value?, key: UnsafePointer<Void>, any: Any) {
+        self.parent = parent
+        self.key = key
+        self.any = any
+    }
+    
+    func valueFor(key: UnsafePointer<Void>) -> Any? {
+        var v: Value! = self
+        do {
+            if v.key == key {
+                return v.any
+            }
+            v = v.parent
+        } while (nil != v)
+        return nil
+    }
 }
 
 


### PR DESCRIPTION
The idea here, is that kind like the google "context" pattern for Go, we can have libraries that can attach some context into the promise chain.  This will allow libraries like Quick to pass data to extensions to Promise<V> like (pseudo-swift):

```
let KEY = "some-constant"
func someFuncReturningAPromise() -> Promise<V> {
   return Promise().withValue(some-private-value, KEY) 
}
```

which can be pulled back in an extension:

```
extension Promise<V> {
  func query(Q) -> Promise<R>!  {
    if let container = valueOf(KEY) as SomePrivateValue {
      ...
    } else {
      return nil
    }
  }
}
```

which would allow custom functions to be tacked onto the promise chain.  they could pick up their internal values without having to expose them to the users of the chain.
